### PR TITLE
Update kotlin to 2.20

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.0.20-RC2" />
+    <option name="version" value="2.0.20" />
   </component>
 </project>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,9 +31,11 @@ dependencies {
 }
 
 kordEx {
+    ignoreIncompatibleKotlinVersion = true
     bot {
         // See https://docs.kordex.dev/data-collection.html
         dataCollection(DataCollection.None)
+
 
         mainClass = "qbtbot.AppKt"
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 detekt = "1.23.6"  # Note: Plugin versions must be updated in the settings.gradle.kts too
-kotlin = "2.0.20-RC2"  # Note: Plugin versions must be updated in the settings.gradle.kts too
+kotlin = "2.0.20"  # Note: Plugin versions must be updated in the settings.gradle.kts too
 
 groovy = "3.0.22"
 jansi = "2.4.1"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,8 +1,8 @@
 pluginManagement {
     plugins {
         // Update this in libs.version.toml when you change it here.
-        kotlin("jvm") version "2.0.20-RC2"
-        kotlin("plugin.serialization") version "2.0.20-RC2"
+        kotlin("jvm") version "2.0.20"
+        kotlin("plugin.serialization") version "2.0.20"
 
         // Update this in libs.version.toml when you change it here.
         id("io.gitlab.arturbosch.detekt") version "1.23.6"


### PR DESCRIPTION
- Update kotlin to 2.20, also upgrade kotlinx.serialization to 2.20.
- Disable incompatible kotlin version failure check in kordex plugin.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update Kotlin and kotlinx.serialization to version 2.20 and adjust the build configuration to disable the incompatible Kotlin version failure check in the kordEx plugin.

Build:
- Update Kotlin version to 2.20 and kotlinx.serialization to 2.20 in the build configuration.
- Disable the incompatible Kotlin version failure check in the kordEx plugin configuration.

<!-- Generated by sourcery-ai[bot]: end summary -->