### PR TITLE
Fix torrents command to bypass discord 2000 character limit

### DIFF
--- a/src/main/kotlin/qbtbot/commands/TorrentInfo.kt
+++ b/src/main/kotlin/qbtbot/commands/TorrentInfo.kt
@@ -39,7 +39,8 @@ class TorrentInfo : Extension() {
                             }
                         }"
                     }.joinToString(separator = "\n\n\n")
-                message.respond(finalMessage)
+                val finalMessageList: List<String> = finalMessage.chunked(MESSAGE_MAX_LENGTH)
+                finalMessageList.forEach { message.respond(it) }
             }
         }
     }
@@ -47,5 +48,6 @@ class TorrentInfo : Extension() {
     private companion object {
         private const val PROGRESS_FACTOR = 100
         private const val TORRENT_NAME_MAX_LENGTH = 50
+        private const val MESSAGE_MAX_LENGTH = 1900
     }
 }


### PR DESCRIPTION
### Changes:

- Fix torrents command to overcome discord 2000-character limit per message by splitting the message in chunks.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the torrents command to handle Discord's message length limit by splitting long messages into chunks and sending them separately.

Bug Fixes:
- Fix the torrents command to bypass Discord's 2000-character limit by splitting messages into smaller chunks.

<!-- Generated by sourcery-ai[bot]: end summary -->