### PR TITLE
Kordex Dependency Upgrade

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,9 @@ dependencies {
     implementation(libs.logback)
     implementation(libs.logback.groovy)
     implementation(libs.logging)
+
+    // TODO: use it once the latest version is available on sonatype again
+//    implementation(libs.doc.generator)
 }
 
 kordEx {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ kx-ser = "1.7.3"
 logback = "1.5.11"
 logback-groovy = "1.14.5"
 logging = "7.0.0"
+doc-gen = "0.1.4"
 
 [libraries]
 detekt = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
@@ -18,3 +19,4 @@ kx-ser = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.
 logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 logback-groovy = { module = "io.github.virtualdogbert:logback-groovy-config", version.ref = "logback-groovy" }
 logging = { module = "io.github.oshai:kotlin-logging", version.ref = "logging" }
+doc-generator = { module = "org.hyacinthbots:doc-generator", version.ref = "doc-gen" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,7 +11,15 @@ pluginManagement {
         id("com.github.johnrengelman.shadow") version "8.1.1"
 
         id("dev.kordex.gradle.docker") version "1.5.2"
-        id("dev.kordex.gradle.kordex") version "1.4.2"
+        id("dev.kordex.gradle.kordex") version "1.5.2"
+    }
+    repositories{
+        gradlePluginPortal()
+        mavenCentral()
+
+        maven("https://snapshots-repo.kordex.dev")
+        maven("https://releases-repo.kordex.dev")
+        maven("https://oss.sonatype.org/content/repositories/snapshots")
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,7 +10,7 @@ pluginManagement {
         id("com.github.jakemarsden.git-hooks") version "0.0.2"
         id("com.github.johnrengelman.shadow") version "8.1.1"
 
-        id("dev.kordex.gradle.docker") version "1.4.2"
+        id("dev.kordex.gradle.docker") version "1.5.2"
         id("dev.kordex.gradle.kordex") version "1.4.2"
     }
 }

--- a/src/main/kotlin/qbtbot/commands/TorrentInfo.kt
+++ b/src/main/kotlin/qbtbot/commands/TorrentInfo.kt
@@ -2,6 +2,7 @@ package qbtbot.commands
 
 import dev.kordex.core.extensions.Extension
 import dev.kordex.core.extensions.chatCommand
+import dev.kordex.core.i18n.toKey
 import dev.kordex.core.utils.respond
 import io.ktor.client.call.body
 import io.ktor.client.request.get
@@ -19,8 +20,8 @@ class TorrentInfo : Extension() {
 
     override suspend fun setup() {
         chatCommand {
-            name = "torrents"
-            description = "Get information of available torrents"
+            name = "torrents".toKey()
+            description = "Get information of available torrents".toKey()
             check { failIf(event.message.author == null) }
             check { failIf(event.message.getGuild().id != testGuild) }
             action {


### PR DESCRIPTION
## Changes
- Upgrade kordex plugins to latest version
- Fix breaking changes that comes with latest kordex version
- Add new dependency but did not use it since there is an issue with version resolution from sonatype. Hence added a todo which will be resolved later.

## Summary by Sourcery

Upgrade kordex plugins to the latest version and address breaking changes. Add a new dependency 'doc-generator' but defer its usage due to version resolution issues with Sonatype.

Enhancements:
- Upgrade kordex plugins to version 1.5.2.

Chores:
- Add new dependency 'doc-generator' version 0.1.4 to the project.